### PR TITLE
sperl_yacc.y: add semicolons at the end of sentences

### DIFF
--- a/sperl_yacc.y
+++ b/sperl_yacc.y
@@ -201,13 +201,13 @@ while_statement
 switch_statement
   : SWITCH '(' term ')' block
     {
-      $$ = SPerl_OP_build_switch_statement(parser, $1, $3, $5)
+      $$ = SPerl_OP_build_switch_statement(parser, $1, $3, $5);
     }
 
 case_statement
   : CASE term ':'
     {
-      $$ = SPerl_OP_build_case_statement(parser, $1, $2)
+      $$ = SPerl_OP_build_case_statement(parser, $1, $2);
     }
 
 default_statement


### PR DESCRIPTION
コンパイル通りませんでした。`sperl_yacc.y` 中のセミコロン抜けを修正しました。