### PR TITLE
Fix spelling mistakes in README.md, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ grammar
      return
       var "$num3"
 
-[Method infomation]
+[Method information]
 [0]name => main, argument_count => 0, return_type => int, op_block => 1b731c10
 [1]name => sum, argument_count => 2, return_type => int, op_block => 1b732280
 ```

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ pacakge -> packages
 packages -> grammar
 
 [Abstract Syntax Tree]
-grammer
+grammar
  package
   const string "Main"
   block

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Static Perl - Fast culculation, parallel process, GC, static typing, VM with  perlish syntax
+# Static Perl - Fast calculation, parallel processing, GC, static typing, VM with  perlish syntax
 
-Do you need **fast Perl**? Static Perl provide fast culculation system on Perl.
+Do you need a **fast Perl**? Static Perl is a fast calculation system of Perl.
 
-- **Fast culculation** - Perl biggest weekpoint is culculation performance. Static Perl provide fast culculation.
-- **Paralel process** - Support paralel process to process array fast
-- **GC** - You don't need to think about freeing memory
+- **Fast calculation** - The Perl's biggest weak point is the calculation performance. Static Perl provides fast calculations.
+- **Parallel processing** - Support parallel processing to manipulate arrays faster
+- **GC** - You don't need to care about freeing memory
 - **Static typing** - Static typing for performance
-- **VM** - Byte code is created and you can run it by Static Perl VM
-- **Perlish syntax** - syntax is very similar with Perl
+- **VM** - Byte codes are generated so that you can run them on Static Perl VM
+- **Perlish syntax** - the syntax is very similar to that of Perl
 
-This is now **developping**.
+This is now under **developing**.
 
-I have implmented only parts of **tokenizer** and **abstract syntax tree generator**.
+I have implemented only parts of **tokenizer** and **abstract syntax tree generator**.
 
 ```
 package Main {
@@ -178,9 +178,9 @@ grammer
 
 ## Test
 
-  gcc  -std=c99 -lm -O -o tmp_sperl_t_array t/sperl_t_array.c *.c && ./tmp_sperl_t_array
-  gcc  -std=c99 -lm -O -o tmp_sperl_t_hash t/sperl_t_hash.c *.c && ./tmp_sperl_t_hash
-  gcc  -std=c99 -lm -O -o tmp_sperl_t_memory_pool t/sperl_t_memory_pool.c *.c && ./tmp_sperl_t_memory_pool
+    gcc  -std=c99 -lm -O -o tmp_sperl_t_array t/sperl_t_array.c *.c && ./tmp_sperl_t_array
+    gcc  -std=c99 -lm -O -o tmp_sperl_t_hash t/sperl_t_hash.c *.c && ./tmp_sperl_t_hash
+    gcc  -std=c99 -lm -O -o tmp_sperl_t_memory_pool t/sperl_t_memory_pool.c *.c && ./tmp_sperl_t_memory_pool
 
 # SPVM specification
 
@@ -188,19 +188,19 @@ grammer
 
 core type is char, byte, short, int, long, float, double.
 
-  char    unsinged integer        1byte
-  byte    singed integer          1byte
-  short   singed integer          2byte
-  int     signed integer          4byte
-  long    singed integer          8byte
-  float   floating-point number   4byte
-  double  floating-point number   8byte
+    char    unsigned integer        1byte
+    byte    singed integer          1byte
+    short   singed integer          2byte
+    int     signed integer          4byte
+    long    singed integer          8byte
+    float   floating-point number   4byte
+    double  floating-point number   8byte
 
 ## Class name
 
 class name first character must be upper case. if class name contain "::", each part first character must be upper case.
 
-  Foo
-  Foo::Bar
-  ABC
-  ABC::DEF
+    Foo
+    Foo::Bar
+    ABC
+    ABC::DEF

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ SUB subname ( optsubargs ) : desctype block -> statement
 statements statement -> statements
 { statements } -> block
 PACKAGE pkgname block -> package
-pacakge -> packages
+package -> packages
 packages -> grammar
 
 [Abstract Syntax Tree]
@@ -189,10 +189,10 @@ grammar
 core type is char, byte, short, int, long, float, double.
 
     char    unsigned integer        1byte
-    byte    singed integer          1byte
-    short   singed integer          2byte
+    byte    signed integer          1byte
+    short   signed integer          2byte
     int     signed integer          4byte
-    long    singed integer          8byte
+    long    signed integer          8byte
     float   floating-point number   4byte
     double  floating-point number   8byte
 

--- a/main/sperl_main.c
+++ b/main/sperl_main.c
@@ -32,7 +32,7 @@ int main(int argc, char *argv[])
   SPerl_OP* op_use = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_USE, package_name, 1);
   op_use->uv.use = use;
   
-  /* Push package use infomation stack */
+  /* Push package use information stack */
   SPerl_ARRAY_push(parser->op_use_stack, op_use);
   
   /* call SPerl_yyparse */

--- a/sperl_dumper.c
+++ b/sperl_dumper.c
@@ -113,7 +113,7 @@ void SPerl_DUMPER_dump_ast(SPerl_PARSER* parser, SPerl_OP* op_base) {
 
 void SPerl_DUMPER_dump_parser(SPerl_PARSER* parser) {
   printf("\n[Abstract Syntax Tree]\n");
-  SPerl_DUMPER_dump_ast(parser, parser->op_grammer);
+  SPerl_DUMPER_dump_ast(parser, parser->op_grammar);
   
   printf("\n[Resolved types]\n");
   SPerl_DUMPER_dump_resolved_types(parser, parser->resolved_types);

--- a/sperl_op.c
+++ b/sperl_op.c
@@ -603,11 +603,11 @@ SPerl_OP* SPerl_OP_build_convert_type(SPerl_PARSER* parser, SPerl_OP* op_type, S
   return op_convert_type;
 }
 
-SPerl_OP* SPerl_OP_build_grammer(SPerl_PARSER* parser, SPerl_OP* op_packages) {
-  SPerl_OP* op_grammer = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_GRAMMER, op_packages->file, op_packages->line);
-  SPerl_OP_sibling_splice(parser, op_grammer, NULL, 0, op_packages);
+SPerl_OP* SPerl_OP_build_grammar(SPerl_PARSER* parser, SPerl_OP* op_packages) {
+  SPerl_OP* op_grammar = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_GRAMMER, op_packages->file, op_packages->line);
+  SPerl_OP_sibling_splice(parser, op_grammar, NULL, 0, op_packages);
   
-  parser->op_grammer = op_grammer;
+  parser->op_grammar = op_grammar;
 
   // Resovle types, check types, and names.
   SPerl_OP_check(parser);
@@ -621,7 +621,7 @@ SPerl_OP* SPerl_OP_build_grammer(SPerl_PARSER* parser, SPerl_OP* op_packages) {
   // Create bytecodes
   SPerl_BYTECODE_BUILDER_build_bytecodes(parser);
   
-  return op_grammer;
+  return op_grammar;
 }
 
 void SPerl_OP_build_const_pool(SPerl_PARSER* parser) {

--- a/sperl_op.c
+++ b/sperl_op.c
@@ -868,7 +868,7 @@ SPerl_OP* SPerl_OP_build_decl_sub(SPerl_PARSER* parser, SPerl_OP* op_sub, SPerl_
   SPerl_OP_sibling_splice(parser, op_sub, op_subargs, 0, op_type);
   SPerl_OP_sibling_splice(parser, op_sub, op_type, 0, op_block);
   
-  // Create sub infomation
+  // Create sub information
   SPerl_SUB* sub = SPerl_SUB_new(parser);
   if (op_sub_name->code == SPerl_OP_C_CODE_NULL) {
     sub->anon = 1;

--- a/sperl_op.c
+++ b/sperl_op.c
@@ -40,7 +40,7 @@ uint8_t* const SPerl_OP_C_CODE_NAMES[] = {
   "NULL",
   "LIST",
   "PUSHMARK",
-  "GRAMMER",
+  "GRAMMAR",
   "NAME",
   "DECL_PACKAGE",
   "DECL_MY_VAR",
@@ -604,7 +604,7 @@ SPerl_OP* SPerl_OP_build_convert_type(SPerl_PARSER* parser, SPerl_OP* op_type, S
 }
 
 SPerl_OP* SPerl_OP_build_grammar(SPerl_PARSER* parser, SPerl_OP* op_packages) {
-  SPerl_OP* op_grammar = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_GRAMMER, op_packages->file, op_packages->line);
+  SPerl_OP* op_grammar = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_GRAMMAR, op_packages->file, op_packages->line);
   SPerl_OP_sibling_splice(parser, op_grammar, NULL, 0, op_packages);
   
   parser->op_grammar = op_grammar;

--- a/sperl_op.h
+++ b/sperl_op.h
@@ -55,7 +55,7 @@ enum {                          // [GROUP]
   SPerl_OP_C_CODE_NULL,         // UNKNOWN
   SPerl_OP_C_CODE_LIST,         // UNKNOWN
   SPerl_OP_C_CODE_PUSHMARK,     // UNKNOWN
-  SPerl_OP_C_CODE_GRAMMER,      // UNKNOWN
+  SPerl_OP_C_CODE_GRAMMAR,      // UNKNOWN
   SPerl_OP_C_CODE_NAME,         // UNKNOWN
   SPerl_OP_C_CODE_DECL_PACKAGE,      // UNKNOWN
   SPerl_OP_C_CODE_DECL_MY_VAR,   // UNKNOWN

--- a/sperl_op.h
+++ b/sperl_op.h
@@ -210,7 +210,7 @@ SPerl_OP* SPerl_OP_build_decl_sub(SPerl_PARSER* parser, SPerl_OP* op_sub, SPerl_
 SPerl_OP* SPerl_OP_build_CONSTVALUE(SPerl_PARSER* parser, SPerl_OP* op_const);
 SPerl_OP* SPerl_OP_build_decl_field(SPerl_PARSER* parser, SPerl_OP* op_has, SPerl_OP* op_field_name, SPerl_OP* type);
 SPerl_OP* SPerl_OP_build_decl_my(SPerl_PARSER* parser, SPerl_OP* op_my, SPerl_OP* op_var, SPerl_OP* op_type);
-SPerl_OP* SPerl_OP_build_grammer(SPerl_PARSER* parser, SPerl_OP* op_packages);
+SPerl_OP* SPerl_OP_build_grammar(SPerl_PARSER* parser, SPerl_OP* op_packages);
 SPerl_OP* SPerl_OP_build_decl_use(SPerl_PARSER* parser, SPerl_OP* op_use, SPerl_OP* op_package_name);
 SPerl_OP* SPerl_OP_build_call_sub(SPerl_PARSER* parser, SPerl_OP* op_invocant, SPerl_OP* op_subname, SPerl_OP* op_terms, _Bool anon);
 void SPerl_OP_build_const_pool(SPerl_PARSER* parser);

--- a/sperl_parser.h
+++ b/sperl_parser.h
@@ -28,8 +28,8 @@ struct SPerl_yy_parser_{
   // Syntax error count
   int32_t error_count;
   
-  // AST grammer
-  SPerl_OP* op_grammer;
+  // AST grammar
+  SPerl_OP* op_grammar;
   
   // Packages
   SPerl_ARRAY* op_packages;

--- a/sperl_yacc.y
+++ b/sperl_yacc.y
@@ -20,9 +20,9 @@
 %type <opval> block enum_block class_block decl_sub opt_decl_things_in_class call_sub call_op
 %type <opval> opt_terms terms term sub_args sub_arg opt_sub_args decl_use decl_thing_in_class decl_things_in_class
 %type <opval> decl_enumeration_values decl_enumeration_value decl_anon_sub
-%type <opval> type package_name field_name sub_name decl_package decl_things_in_grammer opt_decl_enumeration_values type_array
-%type <opval> for_statement while_statement expression opt_decl_things_in_grammer type_sub types not_type_sub opt_term throw_exception
-%type <opval> field array_elem convert_type decl_enum new_object array_init type_name array_length logical_op decl_thing_in_grammer
+%type <opval> type package_name field_name sub_name decl_package decl_things_in_grammar opt_decl_enumeration_values type_array
+%type <opval> for_statement while_statement expression opt_decl_things_in_grammar type_sub types not_type_sub opt_term throw_exception
+%type <opval> field array_elem convert_type decl_enum new_object array_init type_name array_length logical_op decl_thing_in_grammar
 %type <opval> switch_statement case_statement default_statement
 %type <opval> ';'
 
@@ -45,9 +45,9 @@
 %%
 
 grammar
-  : opt_decl_things_in_grammer
+  : opt_decl_things_in_grammar
     {
-      $$ = SPerl_OP_build_grammer(parser, $1);
+      $$ = SPerl_OP_build_grammar(parser, $1);
 
       // Syntax error
       if (parser->error_count) {
@@ -59,12 +59,12 @@ grammar
       }
     }
 
-opt_decl_things_in_grammer
+opt_decl_things_in_grammar
   :	/* Empty */
     {
       $$ = SPerl_OP_newOP_LIST(parser, parser->cur_module_path, parser->cur_line);
     }
-  |	decl_things_in_grammer
+  |	decl_things_in_grammar
     {
       if ($1->code == SPerl_OP_C_CODE_LIST) {
         $$ = $1;
@@ -75,14 +75,14 @@ opt_decl_things_in_grammer
       }
     }
   
-decl_things_in_grammer
-  : decl_things_in_grammer decl_thing_in_grammer
+decl_things_in_grammar
+  : decl_things_in_grammar decl_thing_in_grammar
     {
       $$ = SPerl_OP_append_elem(parser, $1, $2, $1->file, $1->line);
     }
-  | decl_thing_in_grammer
+  | decl_thing_in_grammar
 
-decl_thing_in_grammer
+decl_thing_in_grammar
   : decl_use
   | decl_package
 

--- a/sperl_yacc.y
+++ b/sperl_yacc.y
@@ -54,7 +54,7 @@ grammar
         YYABORT;
       }
       else {
-        // Dump parser infomation
+        // Dump parser information
         SPerl_DUMPER_dump_parser(parser);
       }
     }


### PR DESCRIPTION
- Correct spelling mistakes in `README.md`
- Change phrases and words in `README.md`
- `s/grammer/grammar/g`
- `s/infomation/information/g`