### PR TITLE
Add Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
-sperl
+/sperl
+/libsperl.a
 *.tab.c
 *.tab.h
 core.*
 *.output
-tmp_*
+/tmp_*
 /objs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ sperl
 core.*
 *.output
 tmp_*
+*.o

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ sperl
 core.*
 *.output
 tmp_*
-*.o
+/objs

--- a/Makefile
+++ b/Makefile
@@ -10,22 +10,26 @@ all:
 CC     := gcc
 CFLAGS := -std=c99 -g -O
 LIBS   := -lm
+DIRS   :=
 
+CPPFLAGS = -MD -MF $(@:%.o=%.Po)
 
 # sperl
 
 sperl_SRCS := main/sperl_main.c $(wildcard *.c)
-sperl_OBJS := $(sperl_SRCS:%.c=%.o)
+sperl_OBJS := $(sperl_SRCS:%.c=objs/%.o)
 sperl_LIBS := $(LIBS)
+
+DIRS += objs/main objs
+objs/%.o: %.c | objs/main objs
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+-include $(sperl_OBJS:%.o=%.Po)
 sperl_yacc.tab.c: sperl_yacc.y
 	bison -t -p SPerl_yy -d sperl_yacc.y
 sperl: $(sperl_OBJS)
-	gcc -o $@ $(LDFLAGS) $(sperl_OBJS) $(sperl_LIBS)
+	$(CC) -o $@ $(LDFLAGS) $(sperl_OBJS) $(sperl_LIBS)
 all: sperl
-
-.PHONY: clean
-clean:
-	-rm -f $(sperl_OBJS)
 
 # tests
 
@@ -34,3 +38,12 @@ test: sperl
 	./$< Test
 test2: sperl
 	./$< Test2
+
+# misc
+
+$(DIRS):
+	mkdir -p $@
+
+.PHONY: clean
+clean:
+	-rm -f $(sperl_OBJS) $(sperl_OBJS:%.o=%.Po)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ objs/%.o: %.c | objs objs/main objs/t
 libsperl_SRCS := $(wildcard *.c)
 libsperl_OBJS := $(libsperl_SRCS:%.c=objs/%.o)
 -include $(libsperl_OBJS:%.o=%.Po)
-sperl_yacc.tab.c: sperl_yacc.y
+objs/sperl_toke.o: sperl_toke.c sperl_yacc.tab.h
+objs/sperl_yacc.o: sperl_yacc.c sperl_yacc.tab.h 
+sperl_yacc.tab.h: sperl_yacc.y
 	bison -t -p SPerl_yy -d sperl_yacc.y
 libsperl.a: $(libsperl_OBJS)
 	$(AR) crs $@ $(libsperl_OBJS)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 .SUFFIXES: .c .o
 
 CC     := gcc
-CFLAGS := -std=c99 -O
+CFLAGS := -std=c99 -g -O
 LIBS   := -lm
 
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ sperl: $(sperl_OBJS)
 	gcc -o $@ $(LDFLAGS) $(sperl_OBJS) $(sperl_LIBS)
 all: sperl
 
+.PHONY: clean
+clean:
+	-rm -f $(sperl_OBJS)
+
 # tests
 
 .PHONY: test test2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# -*- mode: makefile-gmake -*-
+
+all:
+.PHONY: all
+
+# Disable the default rule: sperl_yacc.y -> sperl_yacc.c
+.SUFFIXES:
+.SUFFIXES: .c .o
+
+CC     := gcc
+CFLAGS := -std=c99 -O
+LIBS   := -lm
+
+
+# sperl
+
+sperl_SRCS := main/sperl_main.c $(wildcard *.c)
+sperl_OBJS := $(sperl_SRCS:%.c=%.o)
+sperl_LIBS := $(LIBS)
+sperl_yacc.tab.c: sperl_yacc.y
+	bison -t -p SPerl_yy -d sperl_yacc.y
+sperl: $(sperl_OBJS)
+	gcc -o $@ $(LDFLAGS) $(sperl_OBJS) $(sperl_LIBS)
+all: sperl
+
+# tests
+
+.PHONY: test test2
+test: sperl
+	./$< Test
+test2: sperl
+	./$< Test2


### PR DESCRIPTION
I created Makefile for easier builds and tests.

- incremental builds
- automatic dependencies using compiler options `-MD -MF depfile`
- tests

If you like it, could you please review the contents of changes? I would like to consult with you about the following points:

- In this Makefile, the objects `*.o` and dependencies `*.Po` are generated in the sub-directory `objs`. Usually such kind of files are generated in a source directory (which is the directory contains `*.c`), but I decided to generate them in `objs` because I don't want them mess up the source directory. You can specify the directory of objects generated.
- Currently, binaries for tests are created at `tmp_sperl_t_*` as the commands in `README.md` do. This can be changed so that users don't see the test binaries (but just see the results of tests). You can specify the places of test binaries likewise.
- The `main` function in `t/sperl_t_array.c` and `t/sperl_t_hash.c` always exit with the status `1` which usually means a failure. Because of this the chain of tests are stopped unexpectedly. Is there any reason for this? Could you change them so that they return `1` only if some of tests are failed?
- **Edit (added)**: It seems the Makefile is too complicated. I can simplify it or add descriptions as comments.

----

## Description of Makefile

The default target `sperl` is compiled by the following command.

```sh
$ make
```

Tests `tmp_sperl_t_*` can be performed by the following command.

```sh
$ make check
```

Each test can also be invoked separately as follows:

```sh
$ make sperl_t_array
$ make sperl_t_hash
$ make sperl_t_memory_pool
````
