### PR TITLE
Fix type of strings from uint8_t* to const char*

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 .SUFFIXES: .c .o
 
 CC     	 := gcc
-CFLAGS 	 := -std=c99 -g -O
+CFLAGS 	 := -std=c99 -g -O -Wall -Wextra
 LIBS   	 := -lm
 DIRS     :=
 CPPFLAGS  = -MD -MF $(@:%.o=%.Po)

--- a/main/sperl_main.c
+++ b/main/sperl_main.c
@@ -12,7 +12,7 @@ int main(int argc, char *argv[])
   }
   
   // Package name
-  uint8_t* package_name = argv[1];
+  const char* package_name = argv[1];
   
   // Parse
   SPerl_PARSER* parser = SPerl_PARSER_new();

--- a/sperl_allocator.c
+++ b/sperl_allocator.c
@@ -33,7 +33,7 @@ int32_t* SPerl_ALLOCATOR_new_int(SPerl_PARSER* parser) {
 }
 
 uint8_t* SPerl_ALLOCATOR_new_string(SPerl_PARSER* parser, int32_t length) {
-  uint8_t* str = malloc(length + 1);
+  uint8_t* str;
   
   if (length < 40) {
     str = SPerl_MEMORY_POOL_alloc(parser->memory_pool, 40);

--- a/sperl_allocator.c
+++ b/sperl_allocator.c
@@ -32,14 +32,14 @@ int32_t* SPerl_ALLOCATOR_new_int(SPerl_PARSER* parser) {
   return value;
 }
 
-uint8_t* SPerl_ALLOCATOR_new_string(SPerl_PARSER* parser, int32_t length) {
-  uint8_t* str;
+char* SPerl_ALLOCATOR_new_string(SPerl_PARSER* parser, int32_t length) {
+  char* str;
   
   if (length < 40) {
-    str = SPerl_MEMORY_POOL_alloc(parser->memory_pool, 40);
+    str = (char*) SPerl_MEMORY_POOL_alloc(parser->memory_pool, 40);
   }
   else {
-    str = malloc(length + 1);
+    str = (char*) malloc(length + 1);
     SPerl_ARRAY_push(parser->long_str_ptrs, str);
   }
   

--- a/sperl_allocator.h
+++ b/sperl_allocator.h
@@ -5,7 +5,7 @@
 
 SPerl_ARRAY* SPerl_ALLOCATOR_new_array(SPerl_PARSER* parser, int32_t capacity);
 SPerl_HASH* SPerl_ALLOCATOR_new_hash(SPerl_PARSER* parser, int32_t capacity);
-uint8_t* SPerl_ALLOCATOR_new_string(SPerl_PARSER* parser, int32_t length);
+char* SPerl_ALLOCATOR_new_string(SPerl_PARSER* parser, int32_t length);
 int32_t* SPerl_ALLOCATOR_new_int(SPerl_PARSER* parser);
 SPerl_VMCODE* SPerl_ALLOCATOR_new_vmcode(SPerl_PARSER* parser);
 

--- a/sperl_bytecode.c
+++ b/sperl_bytecode.c
@@ -6,7 +6,7 @@
 
 
 
-uint8_t* const SPerl_BYTECODE_C_CODE_NAMES[] = {
+const char* const SPerl_BYTECODE_C_CODE_NAMES[] = {
   "NOP",
   "ACONST_NULL",
   "ICONST_M1",

--- a/sperl_bytecode.h
+++ b/sperl_bytecode.h
@@ -215,6 +215,6 @@ enum {
   SPerl_BYTECODE_C_CODE_IMPDEP2, // Not used
 };
 
-extern uint8_t* const SPerl_BYTECODE_C_CODE_NAMES[];
+extern const char* const SPerl_BYTECODE_C_CODE_NAMES[];
 
 #endif

--- a/sperl_bytecode_builder.c
+++ b/sperl_bytecode_builder.c
@@ -306,7 +306,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecodes(SPerl_PARSER* parser) {
                   SPerl_BYTECODES_push(bytecodes, SPerl_BYTECODE_C_CODE_GETFIELD);
 
                   SPerl_NAME_INFO* name_info = op_cur->uv.name_info;
-                  uint8_t* field_abs_name = name_info->abs_name;
+                  const char* field_abs_name = name_info->abs_name;
                   SPerl_FIELD* field = SPerl_HASH_search(parser->field_abs_name_symtable, field_abs_name, strlen(field_abs_name));
                   int32_t id = field->id;
                   
@@ -321,7 +321,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecodes(SPerl_PARSER* parser) {
                 // Call subroutine
                 SPerl_BYTECODES_push(bytecodes, SPerl_BYTECODE_C_CODE_INVOKESTATIC);
                 SPerl_NAME_INFO* name_info = op_cur->uv.name_info;
-                uint8_t* sub_abs_name = name_info->abs_name;
+                const char* sub_abs_name = name_info->abs_name;
                 SPerl_SUB* sub = SPerl_HASH_search(parser->sub_abs_name_symtable, sub_abs_name, strlen(sub_abs_name));
                 int32_t id = sub->id;
                 
@@ -919,7 +919,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecodes(SPerl_PARSER* parser) {
                   
                   // Call subroutine
                   SPerl_NAME_INFO* name_info = op_cur->first->uv.name_info;
-                  uint8_t* field_abs_name = name_info->abs_name;
+                  const char* field_abs_name = name_info->abs_name;
                   SPerl_FIELD* field = SPerl_HASH_search(parser->field_abs_name_symtable, field_abs_name, strlen(field_abs_name));
                   int32_t id = field->id;
                   

--- a/sperl_constant.c
+++ b/sperl_constant.c
@@ -5,7 +5,7 @@
 #include "sperl_allocator.h"
 #include "sperl_hash.h"
 
-uint8_t* const SPerl_CONSTANT_C_CODE_NAMES[] = {
+const char* const SPerl_CONSTANT_C_CODE_NAMES[] = {
   "BOOLEAN",
   "BYTE",
   "INT",

--- a/sperl_constant.h
+++ b/sperl_constant.h
@@ -13,7 +13,7 @@ enum {
   SPerl_CONSTANT_C_CODE_STRING,
 };
 
-extern uint8_t* const SPerl_CONSTANT_C_CODE_NAMES[];
+extern const char* const SPerl_CONSTANT_C_CODE_NAMES[];
 
 struct SPerl_constant {
   int32_t code;
@@ -22,7 +22,7 @@ struct SPerl_constant {
     int32_t long_value;
     float float_value;
     double double_value;
-    uint8_t* string_value;
+    const char* string_value;
   } uv;
   SPerl_RESOLVED_TYPE* resolved_type;
   int32_t pool_pos;

--- a/sperl_descripter.c
+++ b/sperl_descripter.c
@@ -2,7 +2,7 @@
 #include "sperl_parser.h"
 #include "sperl_allocator.h"
 
-uint8_t* const SPerl_DESCRIPTER_CODE_NAMES[] = {
+const char* const SPerl_DESCRIPTER_CODE_NAMES[] = {
   "const",
   "static",
   "value",

--- a/sperl_descripter.h
+++ b/sperl_descripter.h
@@ -10,7 +10,7 @@ enum {
   SPerl_DESCRIPTER_C_CODE_ENUM
 };
 
-extern uint8_t* const SPerl_DESCRIPTER_CODE_NAMES[];
+extern const char* const SPerl_DESCRIPTER_CODE_NAMES[];
 
 // Field information
 struct SPerl_descripter {

--- a/sperl_hash.c
+++ b/sperl_hash.c
@@ -25,12 +25,12 @@ SPerl_HASH* SPerl_HASH_new(int32_t capacity) {
   return hash;
 }
 
-SPerl_HASH_ENTRY* SPerl_HASH_ENTRY_new(uint8_t* key, int32_t length, void* value) {
+SPerl_HASH_ENTRY* SPerl_HASH_ENTRY_new(const char* key, int32_t length, void* value) {
   
   SPerl_HASH_ENTRY* new_entry = malloc(sizeof(SPerl_HASH_ENTRY));
   memset(new_entry, 0, sizeof(SPerl_HASH_ENTRY));
   
-  new_entry->key = (uint8_t*)malloc(sizeof(uint8_t) * (length + 1));
+  new_entry->key = (char*)malloc(sizeof(char) * (length + 1));
   strncpy(new_entry->key, key, length);
   new_entry->key[length] = '\0';
   new_entry->value = value;
@@ -38,7 +38,7 @@ SPerl_HASH_ENTRY* SPerl_HASH_ENTRY_new(uint8_t* key, int32_t length, void* value
   return new_entry;
 }
 
-void* SPerl_HASH_insert_norehash(SPerl_HASH* hash, uint8_t* key, int32_t length, void* value) {
+void* SPerl_HASH_insert_norehash(SPerl_HASH* hash, const char* key, int32_t length, void* value) {
 
   int64_t hash_value = SPerl_HASH_FUNC_calc_hash(key, length);
   int32_t index = hash_value % hash->capacity;
@@ -86,7 +86,7 @@ void SPerl_HASH_rehash(SPerl_HASH* hash, int32_t new_capacity) {
   for (i = 0; i < hash->count; i++) {
     SPerl_HASH_ENTRY* entry = entries[i];
     
-    uint8_t* key = entry->key;
+    const char* key = entry->key;
     if (key) {
       int32_t length = strlen(key);
       void* value = SPerl_HASH_search(hash, key, length);
@@ -95,7 +95,7 @@ void SPerl_HASH_rehash(SPerl_HASH* hash, int32_t new_capacity) {
     
     SPerl_HASH_ENTRY* next_entry = entry->next;
     while (next_entry) {
-      uint8_t* key = next_entry->key;
+      const char* key = next_entry->key;
       if (key) {
         int32_t length = strlen(key);
         void* value = SPerl_HASH_search(hash, key, length);
@@ -112,7 +112,7 @@ void SPerl_HASH_rehash(SPerl_HASH* hash, int32_t new_capacity) {
   hash->entries = new_hash->entries;
 }
 
-void* SPerl_HASH_insert(SPerl_HASH* hash, uint8_t* key, int32_t length, void* value) {
+void* SPerl_HASH_insert(SPerl_HASH* hash, const char* key, int32_t length, void* value) {
   if (hash == NULL) {
     return 0;
   }
@@ -127,7 +127,7 @@ void* SPerl_HASH_insert(SPerl_HASH* hash, uint8_t* key, int32_t length, void* va
   SPerl_HASH_insert_norehash(hash, key, length, value);
 }
 
-void* SPerl_HASH_search(SPerl_HASH* hash, uint8_t* key, int32_t length) {
+void* SPerl_HASH_search(SPerl_HASH* hash, const char* key, int32_t length) {
   if (!hash) {
     return 0;
   }

--- a/sperl_hash.h
+++ b/sperl_hash.h
@@ -14,9 +14,9 @@ struct SPerl_hash {
 SPerl_HASH_ENTRY* SPerl_HASH_ENTRY_new();
 SPerl_HASH* SPerl_HASH_new(int32_t capacity);
 void SPerl_HASH_rehash(SPerl_HASH* hash_ptr, int32_t new_capacity);
-void* SPerl_HASH_insert_norehash(SPerl_HASH* hash, uint8_t* key, int32_t length, void* value);
-void* SPerl_HASH_insert(SPerl_HASH* hash, uint8_t* key, int32_t length, void* value);
-void* SPerl_HASH_search(SPerl_HASH* hash, uint8_t* key, int32_t length);
+void* SPerl_HASH_insert_norehash(SPerl_HASH* hash, const char* key, int32_t length, void* value);
+void* SPerl_HASH_insert(SPerl_HASH* hash, const char* key, int32_t length, void* value);
+void* SPerl_HASH_search(SPerl_HASH* hash, const char* key, int32_t length);
 void SPerl_HASH_free(SPerl_HASH* hash);
 
 #endif

--- a/sperl_hash_entry.h
+++ b/sperl_hash_entry.h
@@ -5,7 +5,7 @@
 
 // Hash entry
 struct SPerl_hash_entry {
-  uint8_t* key;
+  char* key;
   void* value;
   SPerl_HASH_ENTRY* next;
 };

--- a/sperl_hash_func.c
+++ b/sperl_hash_func.c
@@ -3,12 +3,12 @@
 
 #include "sperl_hash_func.h"
 
-int64_t SPerl_HASH_FUNC_calc_hash(uint8_t* str, int32_t len) {
-  uint8_t* str_tmp = str;
-  int64_t hash = 5381;
+int64_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len) {
+  const char* str_tmp = str;
+  uint64_t hash = 5381;
   while (len--) {
-    hash = ((hash << 5) + hash) + *str_tmp++;
+    hash = ((hash << 5) + hash) + (uint8_t) *str_tmp++;
   }
   
-  return (uint32_t)hash;
+  return (uint32_t) hash;
 }

--- a/sperl_hash_func.h
+++ b/sperl_hash_func.h
@@ -4,6 +4,6 @@
 #include "sperl_base.h"
 
 // Hash function
-int64_t SPerl_HASH_FUNC_calc_hash(uint8_t* str, int32_t len);
+int64_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len);
 
 #endif

--- a/sperl_name_info.h
+++ b/sperl_name_info.h
@@ -7,7 +7,7 @@ struct SPerl_name_info {
   SPerl_OP* op_var;
   SPerl_OP* op_name;
   _Bool anon;
-  uint8_t* abs_name;
+  const char* abs_name;
 };
 
 SPerl_NAME_INFO* SPerl_NAME_INFO_new(SPerl_PARSER* parser);

--- a/sperl_op.c
+++ b/sperl_op.c
@@ -32,7 +32,7 @@
 #include "sperl_op_checker.h"
 #include "sperl_switch_info.h"
 
-uint8_t* const SPerl_OP_C_CODE_NAMES[] = {
+const char* const SPerl_OP_C_CODE_NAMES[] = {
   "IF",
   "ELSIF",
   "ELSE",
@@ -349,14 +349,14 @@ SPerl_RESOLVED_TYPE* SPerl_OP_get_resolved_type(SPerl_PARSER* parser, SPerl_OP* 
     }
     case SPerl_OP_C_CODE_CALL_SUB: {
       SPerl_NAME_INFO* name_info = op->uv.name_info;
-      uint8_t* abs_name = name_info->abs_name;
+      const char* abs_name = name_info->abs_name;
       SPerl_SUB* sub = SPerl_HASH_search(parser->sub_abs_name_symtable, abs_name, strlen(abs_name));
       resolved_type = sub->op_return_type->uv.type->resolved_type;
       break;
     }
     case SPerl_OP_C_CODE_FIELD: {
       SPerl_NAME_INFO* name_info = op->uv.name_info;
-      uint8_t* abs_name = name_info->abs_name;
+      const char* abs_name = name_info->abs_name;
       SPerl_FIELD* field = SPerl_HASH_search(parser->field_abs_name_symtable, abs_name, strlen(abs_name));
       resolved_type = field->op_type->uv.type->resolved_type;
       break;
@@ -541,11 +541,11 @@ void SPerl_OP_check(SPerl_PARSER* parser) {
 void SPerl_OP_check_sub_name(SPerl_PARSER* parser, SPerl_OP* op_name) {
   SPerl_NAME_INFO* name_info = op_name->uv.name_info;
   
-  uint8_t* sub_abs_name;
+  const char* sub_abs_name;
   SPerl_OP* op;
   if (name_info->op_var) {
-    uint8_t* package_name = name_info->op_var->uv.var->op_my_var->uv.my_var->op_type->uv.type->resolved_type->name;
-    uint8_t* base_name = name_info->op_name->uv.name;
+    const char* package_name = name_info->op_var->uv.var->op_my_var->uv.my_var->op_type->uv.type->resolved_type->name;
+    const char* base_name = name_info->op_name->uv.name;
     sub_abs_name = SPerl_OP_create_abs_name(parser, package_name, base_name);
   }
   else if (name_info->op_name) {
@@ -568,10 +568,10 @@ void SPerl_OP_check_sub_name(SPerl_PARSER* parser, SPerl_OP* op_name) {
 void SPerl_OP_check_field_name(SPerl_PARSER* parser, SPerl_OP* op_name_info) {
   SPerl_NAME_INFO* name_info = op_name_info->uv.name_info;
   
-  uint8_t* field_abs_name;
+  const char* field_abs_name;
   SPerl_OP* op;
-  uint8_t* package_name = name_info->op_var->uv.var->op_my_var->uv.my_var->op_type->uv.type->resolved_type->name;
-  uint8_t* base_name = name_info->op_name->uv.name;
+  const char* package_name = name_info->op_var->uv.var->op_my_var->uv.my_var->op_type->uv.type->resolved_type->name;
+  const char* base_name = name_info->op_name->uv.name;
   field_abs_name = SPerl_OP_create_abs_name(parser, package_name, base_name);
   
   name_info->abs_name = field_abs_name;
@@ -690,10 +690,10 @@ void SPerl_OP_build_const_pool(SPerl_PARSER* parser) {
   }
 }
 
-uint8_t* SPerl_OP_create_abs_name(SPerl_PARSER* parser, uint8_t* package_name, uint8_t* base_name) {
+const char* SPerl_OP_create_abs_name(SPerl_PARSER* parser, const char* package_name, const char* base_name) {
   int32_t length = strlen(package_name) + 2 + strlen(base_name);
   
-  uint8_t* abs_name = SPerl_ALLOCATOR_new_string(parser, length);
+  char* abs_name = SPerl_ALLOCATOR_new_string(parser, length);
   
   sprintf(abs_name, "%s::%s", package_name, base_name);
   
@@ -706,7 +706,7 @@ SPerl_OP* SPerl_OP_build_decl_package(SPerl_PARSER* parser, SPerl_OP* op_package
   SPerl_OP_sibling_splice(parser, op_package, NULL, 0, op_package_name);
   SPerl_OP_sibling_splice(parser, op_package, op_package_name, 0, op_block);
   
-  uint8_t* package_name = op_package_name->uv.name;
+  const char* package_name = op_package_name->uv.name;
   SPerl_HASH* package_symtable = parser->package_symtable;
   
   // Redeclaration package error
@@ -744,7 +744,7 @@ SPerl_OP* SPerl_OP_build_decl_package(SPerl_PARSER* parser, SPerl_OP* op_package
       if (op_decl->code == SPerl_OP_C_CODE_DECL_FIELD) {
         SPerl_OP* op_field = op_decl;
         SPerl_FIELD* field = op_field->uv.field;
-        uint8_t* field_name = field->op_name->uv.name;
+        const char* field_name = field->op_name->uv.name;
         SPerl_FIELD* found_field
           = SPerl_HASH_search(field_symtable, field_name, strlen(field_name));
         if (found_field) {
@@ -757,7 +757,7 @@ SPerl_OP* SPerl_OP_build_decl_package(SPerl_PARSER* parser, SPerl_OP* op_package
           SPerl_HASH_insert(field_symtable, field_name, strlen(field_name), field);
           
           // Field absolute name
-          uint8_t* field_abs_name = SPerl_OP_create_abs_name(parser, package_name, field_name);
+          const char* field_abs_name = SPerl_OP_create_abs_name(parser, package_name, field_name);
           SPerl_HASH_insert(parser->field_abs_name_symtable, field_abs_name, strlen(field_abs_name), field);
 
           SPerl_SUB* field_ = SPerl_HASH_search(parser->field_abs_name_symtable, field_abs_name, strlen(field_abs_name));
@@ -781,8 +781,8 @@ SPerl_OP* SPerl_OP_build_decl_package(SPerl_PARSER* parser, SPerl_OP* op_package
       
       if (!sub->anon) {
         SPerl_OP* op_sub_name = sub->op_name;
-        uint8_t* sub_name = op_sub_name->uv.name;
-        uint8_t* sub_abs_name = SPerl_OP_create_abs_name(parser, package_name, sub_name);
+        const char* sub_name = op_sub_name->uv.name;
+        const char* sub_abs_name = SPerl_OP_create_abs_name(parser, package_name, sub_name);
         
         SPerl_SUB* found_sub = NULL;
         found_sub = SPerl_HASH_search(sub_abs_name_symtable, sub_abs_name, strlen(sub_abs_name));
@@ -821,7 +821,7 @@ SPerl_OP* SPerl_OP_build_decl_use(SPerl_PARSER* parser, SPerl_OP* op_use, SPerl_
   use->op_package_name = op_package_name;
   op_use->uv.use = use;
 
-  uint8_t* package_name = op_package_name->uv.name;
+  const char* package_name = op_package_name->uv.name;
   
   SPerl_USE* found_use = SPerl_HASH_search(parser->use_package_symtable, package_name, strlen(package_name));
   
@@ -1008,7 +1008,7 @@ SPerl_OP* SPerl_OP_build_call_sub(SPerl_PARSER* parser, SPerl_OP* op_invocant, S
   SPerl_NAME_INFO* name_info = SPerl_NAME_INFO_new(parser);
   
   if (!anon) {
-    uint8_t* sub_name = op_sub_name->uv.name;
+    const char* sub_name = op_sub_name->uv.name;
     SPerl_OP* op_name = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_NAME, op_invocant->file, op_invocant->line);
     
     if (strstr(sub_name, ":")) {
@@ -1021,7 +1021,7 @@ SPerl_OP* SPerl_OP_build_call_sub(SPerl_PARSER* parser, SPerl_OP* op_invocant, S
         name_info->op_name = op_sub_name;
       }
       else {
-        uint8_t* sub_abs_name = SPerl_OP_create_abs_name(parser, "CORE", sub_name);
+        const char* sub_abs_name = SPerl_OP_create_abs_name(parser, "CORE", sub_name);
         op_name->uv.name = sub_abs_name;
         name_info->op_name = op_name;
       }
@@ -1120,7 +1120,7 @@ SPerl_OP* SPerl_OP_build_type_sub(SPerl_PARSER* parser, SPerl_OP* op_argument_ty
   SPerl_TYPE* type = SPerl_TYPE_new(parser);
   type->code = SPerl_TYPE_C_CODE_SUB;
   
-  uint8_t* file = NULL;
+  const char* file = NULL;
   int32_t line = -1;
   
   // sub type
@@ -1158,7 +1158,7 @@ SPerl_OP* SPerl_OP_build_type_sub(SPerl_PARSER* parser, SPerl_OP* op_argument_ty
   return op_type_sub;
 }
 
-SPerl_OP* SPerl_OP_append_elem(SPerl_PARSER* parser, SPerl_OP *first, SPerl_OP *last, uint8_t* file, uint32_t line) {
+SPerl_OP* SPerl_OP_append_elem(SPerl_PARSER* parser, SPerl_OP *first, SPerl_OP *last, const char* file, uint32_t line) {
   if (!first) {
     return last;
   }
@@ -1180,7 +1180,7 @@ SPerl_OP* SPerl_OP_append_elem(SPerl_PARSER* parser, SPerl_OP *first, SPerl_OP *
   }
 }
 
-SPerl_OP* SPerl_OP_newOP_LIST(SPerl_PARSER* parser, uint8_t* file, uint32_t line) {
+SPerl_OP* SPerl_OP_newOP_LIST(SPerl_PARSER* parser, const char* file, uint32_t line) {
   
   SPerl_OP* op_pushmark = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_PUSHMARK, file, line);
   
@@ -1191,7 +1191,7 @@ SPerl_OP* SPerl_OP_newOP_LIST(SPerl_PARSER* parser, uint8_t* file, uint32_t line
 }
 
 
-SPerl_OP* SPerl_OP_newOP(SPerl_PARSER* parser, int32_t code, uint8_t* file, uint32_t line) {
+SPerl_OP* SPerl_OP_newOP(SPerl_PARSER* parser, int32_t code, const char* file, uint32_t line) {
 
   SPerl_OP *op = SPerl_MEMORY_POOL_alloc(parser->memory_pool, sizeof(SPerl_OP));
   

--- a/sperl_op.h
+++ b/sperl_op.h
@@ -125,7 +125,7 @@ enum {                          // [GROUP]
   SPerl_OP_C_CODE_SWITCH_CONDITION,
 };
 
-extern uint8_t* const SPerl_OP_C_CODE_NAMES[];
+extern const char* const SPerl_OP_C_CODE_NAMES[];
 
 enum {
   // Block flag
@@ -152,13 +152,13 @@ struct SPerl_op {
   SPerl_OP* first;
   SPerl_OP* last;
   SPerl_OP* sibparent;
-  uint8_t* file;
+  const char* file;
   int32_t line;
   _Bool moresib;
   _Bool lvalue;
   _Bool condition;
   union {
-    uint8_t* name;
+    const char* name;
     SPerl_RESOLVED_TYPE* resolved_type;
     SPerl_MY_VAR* my_var;
     SPerl_SUB* sub;
@@ -221,11 +221,11 @@ SPerl_OP* SPerl_OP_build_grammar(SPerl_PARSER* parser, SPerl_OP* op_packages);
 SPerl_OP* SPerl_OP_build_decl_use(SPerl_PARSER* parser, SPerl_OP* op_use, SPerl_OP* op_package_name);
 SPerl_OP* SPerl_OP_build_call_sub(SPerl_PARSER* parser, SPerl_OP* op_invocant, SPerl_OP* op_subname, SPerl_OP* op_terms, _Bool anon);
 void SPerl_OP_build_const_pool(SPerl_PARSER* parser);
-SPerl_OP* SPerl_OP_newOP_LIST(SPerl_PARSER* parser, uint8_t* file, uint32_t line);
+SPerl_OP* SPerl_OP_newOP_LIST(SPerl_PARSER* parser, const char* file, uint32_t line);
 SPerl_OP* SPerl_OP_build_convert_type(SPerl_PARSER* parser, SPerl_OP* op_type, SPerl_OP* op_term);
 void SPerl_OP_resolve_op_convert_type(SPerl_PARSER* parser, SPerl_OP* op_convert_type);
 
-uint8_t* SPerl_OP_create_abs_name(SPerl_PARSER* parser, uint8_t* package_name, uint8_t* base_name);
+const char* SPerl_OP_create_abs_name(SPerl_PARSER* parser, const char* package_name, const char* base_name);
 
 SPerl_OP* SPerl_OP_sibling_splice(SPerl_PARSER* parser, SPerl_OP* parent, SPerl_OP* start, int32_t del_count, SPerl_OP *insert);
 
@@ -236,8 +236,8 @@ void SPerl_OP_maybesib_set(SPerl_PARSER* parser, SPerl_OP* o, SPerl_OP* sib, SPe
 
 SPerl_OP* SPerl_OP_build_decl_enum(SPerl_PARSER* parser, SPerl_OP* op_enum, SPerl_OP* op_enum_block);
 
-SPerl_OP* SPerl_OP_newOP(SPerl_PARSER* parser, int32_t code, uint8_t* file, uint32_t line);
+SPerl_OP* SPerl_OP_newOP(SPerl_PARSER* parser, int32_t code, const char* file, uint32_t line);
 
-SPerl_OP* SPerl_OP_append_elem(SPerl_PARSER* parser, SPerl_OP *first, SPerl_OP *last, uint8_t* file, uint32_t line);
+SPerl_OP* SPerl_OP_append_elem(SPerl_PARSER* parser, SPerl_OP *first, SPerl_OP *last, const char* file, uint32_t line);
 
 #endif

--- a/sperl_parser.c
+++ b/sperl_parser.c
@@ -42,7 +42,7 @@ SPerl_PARSER* SPerl_PARSER_new() {
   // Core types
   for (int32_t i = 0; i < SPerl_RESOLVED_TYPE_C_CORE_LENGTH; i++) {
     // Name
-    uint8_t* name = SPerl_RESOLVED_TYPE_C_CORE_NAMES[i];
+    const char* name = SPerl_RESOLVED_TYPE_C_CORE_NAMES[i];
     
     // Name
     SPerl_OP* op_name = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_NAME, "CORE", 1);
@@ -51,7 +51,7 @@ SPerl_PARSER* SPerl_PARSER_new() {
     
     // Resolved type
     SPerl_RESOLVED_TYPE* resolved_type = SPerl_RESOLVED_TYPE_new(parser);
-    SPerl_ARRAY_push(resolved_type->part_names, name);
+    SPerl_ARRAY_push(resolved_type->part_names, (void*) name);
     resolved_type->name = name;
     resolved_type->name_length = strlen(name);
     resolved_type->id = i;
@@ -94,8 +94,8 @@ SPerl_PARSER* SPerl_PARSER_new() {
   // Core array types
   for (int32_t i = 0; i < SPerl_RESOLVED_TYPE_C_CORE_LENGTH; i++) {
     // Name
-    uint8_t* name = SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[i];
-    uint8_t* core_name = SPerl_RESOLVED_TYPE_C_CORE_NAMES[i];
+    const char* name = SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[i];
+    const char* core_name = SPerl_RESOLVED_TYPE_C_CORE_NAMES[i];
     
     // Name
     SPerl_OP* op_name = SPerl_OP_newOP(parser, SPerl_OP_C_CODE_NAME, "CORE", 1);
@@ -103,9 +103,9 @@ SPerl_PARSER* SPerl_PARSER_new() {
     
     // Resolved type
     SPerl_RESOLVED_TYPE* resolved_type = SPerl_RESOLVED_TYPE_new(parser);
-    SPerl_ARRAY_push(resolved_type->part_names, core_name);
-    SPerl_ARRAY_push(resolved_type->part_names, "[");
-    SPerl_ARRAY_push(resolved_type->part_names, "]");
+    SPerl_ARRAY_push(resolved_type->part_names, (void*) core_name);
+    SPerl_ARRAY_push(resolved_type->part_names, (void*) "[");
+    SPerl_ARRAY_push(resolved_type->part_names, (void*) "]");
     
     resolved_type->name = name;
     resolved_type->name_length = strlen(name);
@@ -117,7 +117,7 @@ SPerl_PARSER* SPerl_PARSER_new() {
   return parser;
 }
 
-int32_t SPerl_PARSER_parse(SPerl_PARSER* parser, uint8_t* package_name) {
+int32_t SPerl_PARSER_parse(SPerl_PARSER* parser, const char* package_name) {
 
   /* Build use information */
   SPerl_USE* use = SPerl_USE_new(parser);
@@ -133,7 +133,7 @@ int32_t SPerl_PARSER_parse(SPerl_PARSER* parser, uint8_t* package_name) {
   SPerl_ARRAY_push(parser->op_use_stack, op_use);
   
   // Entry point
-  uint8_t* entry_point = SPerl_ALLOCATOR_new_string(parser, strlen(package_name) + 6);
+  char* entry_point = SPerl_ALLOCATOR_new_string(parser, strlen(package_name) + 6);
   strncpy(entry_point, package_name, strlen(package_name));
   strncpy(entry_point + strlen(package_name), "::main", 6);
   parser->entry_point = entry_point;
@@ -163,7 +163,7 @@ void SPerl_PARSER_free(SPerl_PARSER* parser) {
   
   // Free all string pointers;
   for (int32_t i = 0; i < parser->long_str_ptrs->length; i++) {
-    uint8_t* str = SPerl_ARRAY_fetch(parser->long_str_ptrs, i);
+    void* str = SPerl_ARRAY_fetch(parser->long_str_ptrs, i);
     free(str);
   }
   SPerl_ARRAY_free(parser->long_str_ptrs);

--- a/sperl_parser.h
+++ b/sperl_parser.h
@@ -8,19 +8,19 @@
 // Parser information
 struct SPerl_yy_parser_{
   // Before buffer position
-  uint8_t* befbufptr;
+  const char* befbufptr;
   
   // Current buffer position
-  uint8_t* bufptr;
+  const char* bufptr;
   
   // Expect next token type
   int32_t expect;
 
   // Current file name
-  uint8_t* cur_module_path;
+  const char* cur_module_path;
   
   // Source data
-  uint8_t* cur_src;
+  const char* cur_src;
   
   // Current line number
   int32_t cur_line;
@@ -84,12 +84,12 @@ struct SPerl_yy_parser_{
   SPerl_ARRAY* cur_op_cases;
   
   // Entry point subroutine
-  uint8_t* entry_point;
+  const char* entry_point;
 };
 
 SPerl_PARSER* SPerl_PARSER_new();
 
 void SPerl_PARSER_free(SPerl_PARSER* parser);
-int32_t SPerl_PARSER_parse(SPerl_PARSER* parser, uint8_t* package_name);
+int32_t SPerl_PARSER_parse(SPerl_PARSER* parser, const char* package_name);
 
 #endif

--- a/sperl_resolved_type.c
+++ b/sperl_resolved_type.c
@@ -4,7 +4,7 @@
 #include "sperl_allocator.h"
 #include "sperl_package.h"
 
-uint8_t* const SPerl_RESOLVED_TYPE_C_CORE_NAMES[] = {
+const char* const SPerl_RESOLVED_TYPE_C_CORE_NAMES[] = {
   "boolean",
   "byte",
   "short",
@@ -14,7 +14,7 @@ uint8_t* const SPerl_RESOLVED_TYPE_C_CORE_NAMES[] = {
   "double"
 };
 
-uint8_t* const SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[] = {
+const char* const SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[] = {
   "boolean[]",
   "byte[]",
   "short[]",
@@ -46,8 +46,8 @@ _Bool SPerl_RESOLVED_TYPE_is_array(SPerl_PARSER* parser, SPerl_RESOLVED_TYPE* re
   int32_t length = strlen(resolved_type->name);
   
   if (strlen(resolved_type->name) >= 2) {
-    uint8_t char1 = resolved_type->name[length - 2];
-    uint8_t char2 = resolved_type->name[length - 1];
+    char char1 = resolved_type->name[length - 2];
+    char char2 = resolved_type->name[length - 1];
     
     if (char1 == '[' && char2 == ']') {
       return 1;
@@ -65,10 +65,10 @@ _Bool SPerl_RESOLVED_TYPE_is_multi_array(SPerl_PARSER* parser, SPerl_RESOLVED_TY
   int32_t length = strlen(resolved_type->name);
   
   if (strlen(resolved_type->name) >= 4) {
-    uint8_t char1 = resolved_type->name[length - 4];
-    uint8_t char2 = resolved_type->name[length - 3];
-    uint8_t char3 = resolved_type->name[length - 2];
-    uint8_t char4 = resolved_type->name[length - 1];
+    char char1 = resolved_type->name[length - 4];
+    char char2 = resolved_type->name[length - 3];
+    char char3 = resolved_type->name[length - 2];
+    char char4 = resolved_type->name[length - 1];
     
     if (char1 == '[' && char2 == ']' && char3 == '[' && char4 == ']' ) {
       return 1;
@@ -83,9 +83,9 @@ _Bool SPerl_RESOLVED_TYPE_is_multi_array(SPerl_PARSER* parser, SPerl_RESOLVED_TY
 }
 
 _Bool SPerl_RESOLVED_TYPE_contain_sub(SPerl_PARSER* parser, SPerl_RESOLVED_TYPE* resolved_type) {
-  uint8_t* name = resolved_type->name;
+  const char* name = resolved_type->name;
   
-  uint8_t* found = strchr(name, '(');
+  const char* found = strchr(name, '(');
   if (found) {
     return 1;
   }
@@ -104,9 +104,9 @@ _Bool SPerl_RESOLVED_TYPE_is_integral(SPerl_PARSER* parser, SPerl_RESOLVED_TYPE*
 }
 
 _Bool SPerl_RESOLVED_TYPE_is_core_type_array(SPerl_PARSER* parser, SPerl_RESOLVED_TYPE* resolved_type) {
-  uint8_t* name = resolved_type->name;
+  const char* name = resolved_type->name;
   
-  uint8_t* found = strchr(name, '(');
+  const char* found = strchr(name, '('); // akinomyoga: no one use this
   if (strcmp(name, "boolean[]") == 0 || strcmp(name, "char[]") == 0 || strcmp(name, "byte[]") == 0 || strcmp(name, "short[]") == 0
     || strcmp(name, "int[]") == 0 || strcmp(name, "long[]") == 0 || strcmp(name, "float[]") == 0 || strcmp(name, "double[]") == 0)
   {

--- a/sperl_resolved_type.h
+++ b/sperl_resolved_type.h
@@ -17,15 +17,15 @@ enum {
   SPerl_RESOLVED_TYPE_C_ID_DOUBLE,
 };
 
-extern uint8_t* const SPerl_RESOLVED_TYPE_C_CORE_NAMES[];
+extern const char* const SPerl_RESOLVED_TYPE_C_CORE_NAMES[];
 extern int32_t const SPerl_RESOLVED_TYPE_C_CORE_SIZES[];
 
-extern uint8_t* const SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[];
+extern const char* const SPerl_RESOLVED_TYPE_C_CORE_ARRAY_NAMES[];
 
 struct SPerl_resolved_type {
   int32_t code;
   SPerl_ARRAY* part_names;
-  uint8_t* name;
+  const char* name;
   int32_t name_length;
   int32_t id;
 };

--- a/sperl_type.c
+++ b/sperl_type.c
@@ -15,7 +15,7 @@
 #include "sperl_yacc.h"
 #include "sperl_package.h"
 
-uint8_t* const SPerl_TYPE_C_CODE_NAMES[] = {
+const char* const SPerl_TYPE_C_CODE_NAMES[] = {
   "name",
   "array",
   "sub",
@@ -43,14 +43,14 @@ _Bool SPerl_TYPE_resolve_type(SPerl_PARSER* parser, SPerl_OP* op_type, int32_t n
       }
       else if (part->code == SPerl_TYPE_PART_C_CODE_BYTE) {
         name_length++;
-        SPerl_ARRAY_push(resolved_type_part_names, part->uv.char_name);
+        SPerl_ARRAY_push(resolved_type_part_names, (void*) part->uv.char_name);
       }
       else {
-        uint8_t* part_name = part->uv.op_name->uv.name;
+        const char* part_name = part->uv.op_name->uv.name;
         
         SPerl_PACKAGE* found_package = SPerl_HASH_search(package_symtable, part_name, strlen(part_name));
         if (found_package) {
-          SPerl_ARRAY_push(resolved_type_part_names, part_name);
+          SPerl_ARRAY_push(resolved_type_part_names, (void*) part_name);
         }
         else {
           SPerl_yyerror_format(parser, "unknown package \"%s\" at %s line %d\n", part_name, op_type->file, op_type->line);
@@ -58,10 +58,10 @@ _Bool SPerl_TYPE_resolve_type(SPerl_PARSER* parser, SPerl_OP* op_type, int32_t n
         }
       }
     }
-    uint8_t* resolved_type_name = SPerl_ALLOCATOR_new_string(parser, name_length);
+    char* resolved_type_name = SPerl_ALLOCATOR_new_string(parser, name_length);
     int32_t cur_pos = 0;
     for (int32_t i = 0; i < resolved_type_part_names->length; i++) {
-      uint8_t* resolved_type_part_name = SPerl_ARRAY_fetch(resolved_type_part_names, i);
+      const char* resolved_type_part_name = (const char*) SPerl_ARRAY_fetch(resolved_type_part_names, i);
       int32_t resolved_type_part_name_length = strlen(resolved_type_part_name);
       memcpy(resolved_type_name + cur_pos, resolved_type_part_name, resolved_type_part_name_length);
       cur_pos += resolved_type_part_name_length;

--- a/sperl_type.h
+++ b/sperl_type.h
@@ -11,7 +11,7 @@ enum {
   SPerl_TYPE_C_CODE_SUB,
 };
 
-extern uint8_t* const SPerl_TYPE_C_CODE_NAMES[];
+extern const char* const SPerl_TYPE_C_CODE_NAMES[];
 
 struct SPerl_type {
   int32_t code;

--- a/sperl_type_part.c
+++ b/sperl_type_part.c
@@ -2,7 +2,7 @@
 #include "sperl_parser.h"
 #include "sperl_allocator.h"
 
-uint8_t* const SPerl_TYPE_PART_C_CODE_NAMES[] = {
+const char* const SPerl_TYPE_PART_C_CODE_NAMES[] = {
   "sub",
   "name",
   "char"

--- a/sperl_type_part.h
+++ b/sperl_type_part.h
@@ -9,13 +9,13 @@ enum {
   SPerl_TYPE_PART_C_CODE_BYTE
 };
 
-extern uint8_t* const SPerl_TYPE_PART_C_CODE_NAMES[];
+extern const char* const SPerl_TYPE_PART_C_CODE_NAMES[];
 
 struct SPerl_type_part {
   int32_t code;
   union {
     SPerl_OP* op_name;
-    uint8_t* char_name;
+    const char* char_name;
   } uv;
 };
 

--- a/sperl_vm.c
+++ b/sperl_vm.c
@@ -30,10 +30,10 @@ void SPerl_VM_run(SPerl_PARSER* parser) {
     switch (*cur_bytecode_value_ptr) {
       
       case SPerl_BYTECODE_C_CODE_NOP:
-      
+        // None
         break;
       case SPerl_BYTECODE_C_CODE_ACONST_NULL:
-      
+        
         break;
       case SPerl_BYTECODE_C_CODE_ICONST_M1:
         op_stack_pos++;
@@ -64,31 +64,46 @@ void SPerl_VM_run(SPerl_PARSER* parser) {
         op_stack[op_stack_pos] = 5;
         break;
       case SPerl_BYTECODE_C_CODE_LCONST_0:
-      
+        op_stack_pos++;
+        *((int64_t*)&op_stack[op_stack_pos]) = 0L;
+        op_stack_pos++;
         break;
       case SPerl_BYTECODE_C_CODE_LCONST_1:
-      
+        op_stack_pos++;
+        *((int64_t*)&op_stack[op_stack_pos]) = 1L;
+        op_stack_pos++;
         break;
       case SPerl_BYTECODE_C_CODE_FCONST_0:
-      
+        op_stack_pos++;
+        *((float*)&op_stack[op_stack_pos]) = 0.F;
         break;
       case SPerl_BYTECODE_C_CODE_FCONST_1:
-      
+        op_stack_pos++;
+        *((float*)&op_stack[op_stack_pos]) = 1.F;
         break;
       case SPerl_BYTECODE_C_CODE_FCONST_2:
-      
+        op_stack_pos++;
+        *((float*)&op_stack[op_stack_pos]) = 2.F;
         break;
       case SPerl_BYTECODE_C_CODE_DCONST_0:
-      
+        op_stack_pos++;
+        *((double*)&op_stack[op_stack_pos]) = 0.;
+        op_stack_pos++;
         break;
       case SPerl_BYTECODE_C_CODE_DCONST_1:
-      
+        op_stack_pos++;
+        *((double*)&op_stack[op_stack_pos]) = 1.;
+        op_stack_pos++;
         break;
       case SPerl_BYTECODE_C_CODE_BIPUSH:
-      
+        op_stack_pos++;
+
+        cur_bytecode_value_ptr++;
+        op_stack[op_stack_pos] = *cur_bytecode_value_ptr;
+        
         break;
       case SPerl_BYTECODE_C_CODE_SIPUSH:
-      
+        
         break;
       case SPerl_BYTECODE_C_CODE_LDC:
       

--- a/sperl_vm.c
+++ b/sperl_vm.c
@@ -13,7 +13,7 @@ SPerl_VM* SPerl_VM_new(SPerl_PARSER* parser) {
 }
 
 void SPerl_VM_run(SPerl_PARSER* parser) {
-  uint8_t* entry_point = parser->entry_point;
+  const char* entry_point = parser->entry_point;
   
   SPerl_SUB* sub_entry_point = SPerl_HASH_search(parser->sub_abs_name_symtable, entry_point, strlen(entry_point));
   

--- a/sperl_yacc.c
+++ b/sperl_yacc.c
@@ -10,12 +10,12 @@
 #include "sperl_var.h"
 #include "sperl_op.h"
 
-void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message_template, ...) {
+void SPerl_yyerror_format(SPerl_PARSER* parser, const char* message_template, ...) {
   
   int32_t message_length = 0;
   
   // Prefix
-  uint8_t* prefix = "Error:";
+  const char* prefix = "Error:";
   int32_t prefix_length = strlen(prefix);
    
   // Message template
@@ -23,7 +23,7 @@ void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message_template, ...) 
   
   // Messsage template with prefix
   int32_t message_template_with_prefix_length = prefix_length + message_template_length;
-  uint8_t* message_template_with_prefix = SPerl_ALLOCATOR_new_string(parser, message_template_with_prefix_length);
+  char* message_template_with_prefix = SPerl_ALLOCATOR_new_string(parser, message_template_with_prefix_length);
   strncpy(message_template_with_prefix, prefix, prefix_length);
   strncpy(message_template_with_prefix + prefix_length, message_template, message_template_length);
   message_template_with_prefix[message_template_with_prefix_length] = '\0';
@@ -33,12 +33,12 @@ void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message_template, ...) 
   va_start(args, message_template);
   
   // Argument count
-  uint8_t* found_ptr = message_template_with_prefix;
+  char* found_ptr = message_template_with_prefix;
   while (1) {
     found_ptr = strchr(found_ptr, '%');
     if (found_ptr) {
       if (*(found_ptr + 1) == 's') {
-        uint8_t* arg = va_arg(args, uint8_t*);
+        char* arg = va_arg(args, char*);
         message_length += strlen(arg);
       }
       else if (*(found_ptr + 1) == 'd') {
@@ -57,7 +57,7 @@ void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message_template, ...) 
   }
   va_end(args);
   
-  uint8_t* message = SPerl_ALLOCATOR_new_string(parser, message_length);
+  char* message = SPerl_ALLOCATOR_new_string(parser, message_length);
   
   va_start(args, message_template);
   vsprintf(message, message_template_with_prefix, args);
@@ -67,7 +67,7 @@ void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message_template, ...) 
 }
 
 // Print error
-void SPerl_yyerror(SPerl_PARSER* parser, const uint8_t* message)
+void SPerl_yyerror(SPerl_PARSER* parser, const char* message)
 {
   parser->error_count++;
   
@@ -79,7 +79,7 @@ void SPerl_yyerror(SPerl_PARSER* parser, const uint8_t* message)
     // Current token
     int32_t length = 0;
     int32_t empty_count = 0;
-    uint8_t* ptr = parser->befbufptr;
+    const char* ptr = parser->befbufptr;
     while (ptr != parser->bufptr) {
       if (*ptr == ' ' || *ptr == '\t' || *ptr == '\n') {
         empty_count++;
@@ -89,10 +89,10 @@ void SPerl_yyerror(SPerl_PARSER* parser, const uint8_t* message)
       }
       ptr++;
     }
-    uint8_t* token = calloc(length + 1, sizeof(uint8_t));
+    char* token = (char*) calloc(length + 1, sizeof(char));
     memcpy(token, parser->befbufptr + empty_count, length);
     token[length] = '\0';
-    
+
     fprintf(stderr, "Error: unexpected token \"%s\" at %s line %d\n", token, parser->cur_module_path, parser->cur_line);
   }
 }
@@ -118,7 +118,7 @@ void SPerl_yyprint (FILE *file, int type, YYSTYPE yylval) {
           fprintf(file, "boolean %d", constant->uv.int_value);
           break;
         case SPerl_CONSTANT_C_CODE_BYTE:
-          fprintf(file, "char '%c'", (uint8_t)constant->uv.int_value);
+          fprintf(file, "char '%c'", (char) constant->uv.int_value);
           break;
         case SPerl_CONSTANT_C_CODE_INT:
           fprintf(file, "int %d", constant->uv.int_value);

--- a/sperl_yacc.c
+++ b/sperl_yacc.c
@@ -94,6 +94,7 @@ void SPerl_yyerror(SPerl_PARSER* parser, const char* message)
     token[length] = '\0';
 
     fprintf(stderr, "Error: unexpected token \"%s\" at %s line %d\n", token, parser->cur_module_path, parser->cur_line);
+    free(token);
   }
 }
 

--- a/sperl_yacc.h
+++ b/sperl_yacc.h
@@ -15,8 +15,8 @@ union SPerl_yystype
 extern int SPerl_yydebug;
 
 int SPerl_yyparse(SPerl_PARSER* parser);
-void SPerl_yyerror(SPerl_PARSER* parser, const uint8_t* s);
-void SPerl_yyerror_format(SPerl_PARSER* parser, uint8_t* message, ...);
+void SPerl_yyerror(SPerl_PARSER* parser, const char* s);
+void SPerl_yyerror_format(SPerl_PARSER* parser, const char* message, ...);
 void SPerl_yyprint (FILE *file, int type, YYSTYPE yylval);
 
 #endif

--- a/t/sperl_t_array.c
+++ b/t/sperl_t_array.c
@@ -57,8 +57,8 @@ int main(int argc, char *argv[])
     OK(array->length == 2);
     
     // push pointer value
-    uint8_t* value3 = "foo";
-    SPerl_ARRAY_push(array, value3);
+    const char* value3 = "foo";
+    SPerl_ARRAY_push(array, (void*) value3);
     OK(array->values[2] == value3);
   }
 


### PR DESCRIPTION
取り敢えず @7ae209b7e92565a21212e9a4de8f7fcc84205493 の議論の修正をしました。
変な修正が入っていないかそちらでも各コミットについてご確認いただければと思います。

**追記**:
- Makefile に -Wall -Wextra を追加しました。
- 文字列で uint8_t* になっている部分を const char* もしくは必要に応じて char* に変更しました。
- 明らかな memleak 二箇所は後で PR 出すのも面倒なので直しました。

**追記**
Discussion related to this PR can be found at #5.
