### PR TITLE
Change return type of SPerl_HASH_FUNC_calc_hash to uint32_t

### DIFF
--- a/sperl_hash.c
+++ b/sperl_hash.c
@@ -40,9 +40,9 @@ SPerl_HASH_ENTRY* SPerl_HASH_ENTRY_new(const char* key, int32_t length, void* va
 
 void* SPerl_HASH_insert_norehash(SPerl_HASH* hash, const char* key, int32_t length, void* value) {
 
-  int64_t hash_value = SPerl_HASH_FUNC_calc_hash(key, length);
+  uint32_t hash_value = SPerl_HASH_FUNC_calc_hash(key, length);
   int32_t index = hash_value % hash->capacity;
-  
+
   SPerl_HASH_ENTRY** next_entry_ptr = hash->entries + index;
   SPerl_HASH_ENTRY* next_entry = hash->entries[index];
 
@@ -131,7 +131,7 @@ void* SPerl_HASH_search(SPerl_HASH* hash, const char* key, int32_t length) {
   if (!hash) {
     return 0;
   }
-  int64_t hash_value = SPerl_HASH_FUNC_calc_hash(key, length);
+  uint32_t hash_value = SPerl_HASH_FUNC_calc_hash(key, length);
   int32_t index = hash_value % hash->capacity;
   SPerl_HASH_ENTRY* next_entry = hash->entries[index];
   while (1) {

--- a/sperl_hash_func.c
+++ b/sperl_hash_func.c
@@ -3,12 +3,12 @@
 
 #include "sperl_hash_func.h"
 
-int64_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len) {
+uint32_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len) {
   const char* str_tmp = str;
-  uint64_t hash = 5381;
+  uint32_t hash = 5381;
   while (len--) {
     hash = ((hash << 5) + hash) + (uint8_t) *str_tmp++;
   }
   
-  return (uint32_t) hash;
+  return hash;
 }

--- a/sperl_hash_func.h
+++ b/sperl_hash_func.h
@@ -4,6 +4,6 @@
 #include "sperl_base.h"
 
 // Hash function
-int64_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len);
+uint32_t SPerl_HASH_FUNC_calc_hash(const char* str, int32_t len);
 
 #endif

--- a/t/sperl_t_hash.c
+++ b/t/sperl_t_hash.c
@@ -50,7 +50,7 @@ int main(int argc, char *argv[])
     SPerl_HASH* hash = SPerl_HASH_new(101);
     int32_t value1 = 3;
     SPerl_HASH_insert_norehash(hash, "key1", 4, &value1);
-    int32_t hash_value1 = SPerl_HASH_FUNC_calc_hash("key1", 4);
+    uint32_t hash_value1 = SPerl_HASH_FUNC_calc_hash("key1", 4);
     int32_t index1 = hash_value1 % 101;
     
     OK(*(int32_t*)hash->entries[index1]->value == 3);
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 
     int32_t value2 = 5;
     SPerl_HASH_insert_norehash(hash, "key2", 4, &value2);
-    int32_t hash_value2 = SPerl_HASH_FUNC_calc_hash("key2", 4);
+    uint32_t hash_value2 = SPerl_HASH_FUNC_calc_hash("key2", 4);
     int32_t index2 = hash_value2 % 101;
     
     OK(*(int32_t*)hash->entries[index2]->value == 5);
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
     // Replace
     int32_t value3 = 7;
     int32_t return_value3 = *(int32_t*)SPerl_HASH_insert_norehash(hash, "key1", 4, &value3);
-    int32_t hash_value3 = SPerl_HASH_FUNC_calc_hash("key1", 4);
+    uint32_t hash_value3 = SPerl_HASH_FUNC_calc_hash("key1", 4);
     int32_t index3 = hash_value3 % 101;
     
     OK(*(int32_t*)hash->entries[index3]->value == 7);


### PR DESCRIPTION
Fix #15

取り敢えず `uint32_t` に統一する方向で作ってしまいましたが、#14 の関連で慎重に考えたい場合は未だマージしなくても良いです。