### PR TITLE
Fix null-termination of "resolved_type_name"

### DIFF
--- a/sperl_type.c
+++ b/sperl_type.c
@@ -70,6 +70,7 @@ _Bool SPerl_TYPE_resolve_type(SPerl* sperl, SPerl_OP* op_type, int32_t name_leng
       memcpy(resolved_type_name + cur_pos, resolved_type_part_name, resolved_type_part_name_length);
       cur_pos += resolved_type_part_name_length;
     }
+    resolved_type_name[cur_pos] = '\0';
     
     // Create resolved type id
     SPerl_RESOLVED_TYPE* found_resolved_type = SPerl_HASH_search(parser->resolved_type_symtable, resolved_type_name, strlen(resolved_type_name));


### PR DESCRIPTION
`resolved_type_name` が NUL 終端されていない問題の修正です。よろしくおねがいいたします。

See discussion at [akinomyoga/static-perl@054e7ca](https://github.com/akinomyoga/static-perl/commit/054e7ca0e18968d6dfeaee65f455f606dd71369d#commitcomment-20588439)