### PR TITLE
Fix spelling mistakes

### DIFF
--- a/sperl_bytecode_builder.c
+++ b/sperl_bytecode_builder.c
@@ -95,7 +95,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecode_array(SPerl* sperl) {
                 int32_t max = switch_info->max;
                 int32_t min = switch_info->min;
                 
-                // Machine address to culculate padding
+                // Machine address to calculate padding
                 cur_switch_address = bytecode_array->length - 1;
                 
                 // Padding
@@ -131,7 +131,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecode_array(SPerl* sperl) {
                 
                 int32_t length = switch_info->op_cases->length;
                 
-                // Machine address to culculate padding
+                // Machine address to calculate padding
                 cur_switch_address = bytecode_array->length - 1;
                 
                 // Padding
@@ -237,7 +237,7 @@ void SPerl_BYTECODE_BUILDER_build_bytecode_array(SPerl* sperl) {
                   }
                 }
               }
-              // looupswitch
+              // lookupswitch
               else if (switch_info->code == SPerl_SWITCH_INFO_C_CODE_LOOKUPSWITCH) {
                 int32_t padding = 3 - (cur_switch_address & 3);
 

--- a/sperl_dumper.c
+++ b/sperl_dumper.c
@@ -314,7 +314,7 @@ void SPerl_DUMPER_dump_bytecode_array(SPerl* sperl, SPerl_BYTECODE_ARRAY* byteco
       
       case SPerl_BYTECODE_C_CODE_TABLESWITCH: {
         
-        // Machine address to culculate padding
+        // Machine address to calculate padding
         uintptr_t pc_machine_address = (uintptr_t)&bytecode_array->values[i];
         
         // Padding
@@ -363,7 +363,7 @@ void SPerl_DUMPER_dump_bytecode_array(SPerl* sperl, SPerl_BYTECODE_ARRAY* byteco
       }
       case SPerl_BYTECODE_C_CODE_LOOKUPSWITCH: {
         
-        // Machine address to culculate padding
+        // Machine address to calculate padding
         uintptr_t pc_machine_address = (uintptr_t)&bytecode_array->values[i];
         
         // Padding

--- a/sperl_memory_pool.c
+++ b/sperl_memory_pool.c
@@ -39,7 +39,7 @@ void* SPerl_MEMORY_POOL_alloc(SPerl_MEMORY_POOL* memory_pool, int32_t block_size
   // Calculate capacity
   int32_t current_capacity = base_capacity * pow(2, page_depth - 1);
 
-  // Create next memroy page
+  // Create next memory page
   uint8_t* data_ptr;
   if (current_pos + block_size > current_capacity) {
     page_depth++;

--- a/sperl_vm.c
+++ b/sperl_vm.c
@@ -1027,10 +1027,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1060,10 +1060,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1093,10 +1093,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1126,10 +1126,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1159,10 +1159,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1189,10 +1189,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
         
         vm->frame = &frame_stack[frame_stack_top];
         
-        // Resotre operand stack
+        // Restore operand stack
         operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
         
-        // Resotre vars
+        // Restore vars
         vars = &vm->call_stack[vm->frame->vars_base];
         
         // Restore operand stack top
@@ -1345,10 +1345,10 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
           frame_stack_top--;
           vm->frame = &frame_stack[frame_stack_top];
           
-          // Resotre operand stack
+          // Restore operand stack
           operand_stack = &vm->call_stack[vm->frame->operand_stack_base];
           
-          // Resotre vars
+          // Restore vars
           vars = &vm->call_stack[vm->frame->vars_base];
           
           // Restore operand stack top

--- a/t/sperl_t_memory_pool.c
+++ b/t/sperl_t_memory_pool.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     OK(int_ptr8->b == 0);
   }
   
-  // Crete next memroy node
+  // Crete next memory node
   {
     SPerl_MEMORY_POOL* memory_pool = SPerl_MEMORY_POOL_new(sizeof(int32_t));
     

--- a/t/sperl_t_memory_pool.c
+++ b/t/sperl_t_memory_pool.c
@@ -74,7 +74,7 @@ int main(int argc, char *argv[])
     OK(int_ptr8->b == 0);
   }
   
-  // Crete next memory node
+  // Create next memory node
   {
     SPerl_MEMORY_POOL* memory_pool = SPerl_MEMORY_POOL_new(sizeof(int32_t));
     


### PR DESCRIPTION
細かい点ですがよろしくおねがいいたします。

- culculate → calculate
- memroy → memory
- looupswitch → lookupswitch

**追記**

- crete → create
- resotre → restore