### PR TITLE
Remove extra semicolons

### DIFF
--- a/sperl_vm.c
+++ b/sperl_vm.c
@@ -833,7 +833,7 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
       case SPerl_BYTECODE_C_CODE_FCMPL:
         *(int32_t*)&operand_stack[operand_stack_top - 1]
           = (*(float*)&operand_stack[operand_stack_top - 1] > *(float*)&operand_stack[operand_stack_top])
-          + (*(float*)&operand_stack[operand_stack_top - 1] < *(float*)&operand_stack[operand_stack_top]) * -1;
+          + (*(float*)&operand_stack[operand_stack_top - 1] < *(float*)&operand_stack[operand_stack_top]) * -1
           + -!!(
             isnan(*(float*)&operand_stack[operand_stack_top - 1])
             | isnan(*(float*)&operand_stack[operand_stack_top])
@@ -844,7 +844,7 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
       case SPerl_BYTECODE_C_CODE_FCMPG:
         *(int32_t*)&operand_stack[operand_stack_top - 1]
           = (*(float*)&operand_stack[operand_stack_top - 1] > *(float*)&operand_stack[operand_stack_top])
-          + (*(float*)&operand_stack[operand_stack_top - 1] < *(float*)&operand_stack[operand_stack_top]) * -1;
+          + (*(float*)&operand_stack[operand_stack_top - 1] < *(float*)&operand_stack[operand_stack_top]) * -1
           + !!(
             isnan(*(float*)&operand_stack[operand_stack_top - 1])
             | isnan(*(float*)&operand_stack[operand_stack_top])
@@ -855,7 +855,7 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
       case SPerl_BYTECODE_C_CODE_DCMPL:
         *(int32_t*)&operand_stack[operand_stack_top - 1]
           = (*(double*)&operand_stack[operand_stack_top - 1] > *(double*)&operand_stack[operand_stack_top])
-          + (*(double*)&operand_stack[operand_stack_top - 1] < *(double*)&operand_stack[operand_stack_top]) * -1;
+          + (*(double*)&operand_stack[operand_stack_top - 1] < *(double*)&operand_stack[operand_stack_top]) * -1
           + -!!(
             isnan(*(double*)&operand_stack[operand_stack_top - 1])
             | isnan(*(double*)&operand_stack[operand_stack_top])
@@ -866,7 +866,7 @@ void SPerl_VM_call_sub(SPerl* sperl, SPerl_VM* vm, const char* sub_base_name) {
       case SPerl_BYTECODE_C_CODE_DCMPG:
         *(int32_t*)&operand_stack[operand_stack_top - 1]
           = (*(double*)&operand_stack[operand_stack_top - 1] > *(double*)&operand_stack[operand_stack_top])
-          + (*(double*)&operand_stack[operand_stack_top - 1] < *(double*)&operand_stack[operand_stack_top]) * -1;
+          + (*(double*)&operand_stack[operand_stack_top - 1] < *(double*)&operand_stack[operand_stack_top]) * -1
           + !!(
             isnan(*(double*)&operand_stack[operand_stack_top - 1])
             | isnan(*(double*)&operand_stack[operand_stack_top])


### PR DESCRIPTION
余分なセミコロンがあるために `nan` の時の処理の記述が意味を為していません (コンパイル時に警告が出ていました)。
セミコロンを除去しました。よろしくおねがいいたします。