### PR TITLE
change argument type of SPerl_ARRAY_push

### DIFF
--- a/sperl_array.c
+++ b/sperl_array.c
@@ -21,7 +21,7 @@ SPerl_ARRAY* SPerl_ARRAY_new(int32_t capacity) {
   return array;
 }
 
-void SPerl_ARRAY_push(SPerl_ARRAY* array, void* value) {
+void SPerl_ARRAY_push(SPerl_ARRAY* array, const void* value) {
   int32_t length = array->length;
   int32_t capacity = array->capacity;
   
@@ -32,7 +32,8 @@ void SPerl_ARRAY_push(SPerl_ARRAY* array, void* value) {
     array->capacity = new_capacity;
   }
   
-  array->values[length] = value;
+  /* Casting away a const qualification, I know what I'm doing. */
+  array->values[length] = (void*) value;
   array->length++;
 }
 

--- a/sperl_array.h
+++ b/sperl_array.h
@@ -12,7 +12,7 @@ struct SPerl_array {
 
 // Array function
 SPerl_ARRAY* SPerl_ARRAY_new(int32_t capacity);
-void SPerl_ARRAY_push(SPerl_ARRAY* array, void* value);
+void SPerl_ARRAY_push(SPerl_ARRAY* array, const void* value);
 void* SPerl_ARRAY_fetch(SPerl_ARRAY* array, int32_t index);
 void* SPerl_ARRAY_pop(SPerl_ARRAY* array);
 void SPerl_ARRAY_free(SPerl_ARRAY* array);

--- a/sperl_parser.c
+++ b/sperl_parser.c
@@ -48,7 +48,7 @@ SPerl_PARSER* SPerl_PARSER_new(SPerl* sperl) {
     
     // Resolved type
     SPerl_RESOLVED_TYPE* resolved_type = SPerl_RESOLVED_TYPE_new(sperl);
-    SPerl_ARRAY_push(resolved_type->part_names, (void*) name);
+    SPerl_ARRAY_push(resolved_type->part_names, name);
     resolved_type->name = name;
     resolved_type->name_length = strlen(name);
     resolved_type->id = i;
@@ -100,9 +100,9 @@ SPerl_PARSER* SPerl_PARSER_new(SPerl* sperl) {
     
     // Resolved type
     SPerl_RESOLVED_TYPE* resolved_type = SPerl_RESOLVED_TYPE_new(sperl);
-    SPerl_ARRAY_push(resolved_type->part_names, (void*) core_name);
-    SPerl_ARRAY_push(resolved_type->part_names, (void*) "[");
-    SPerl_ARRAY_push(resolved_type->part_names, (void*) "]");
+    SPerl_ARRAY_push(resolved_type->part_names, core_name);
+    SPerl_ARRAY_push(resolved_type->part_names, "[");
+    SPerl_ARRAY_push(resolved_type->part_names, "]");
     
     resolved_type->name = name;
     resolved_type->name_length = strlen(name);

--- a/sperl_type.c
+++ b/sperl_type.c
@@ -47,14 +47,14 @@ _Bool SPerl_TYPE_resolve_type(SPerl* sperl, SPerl_OP* op_type, int32_t name_leng
       }
       else if (part->code == SPerl_TYPE_PART_C_CODE_BYTE) {
         name_length++;
-        SPerl_ARRAY_push(resolved_type_part_names, (void*) part->uv.char_name);
+        SPerl_ARRAY_push(resolved_type_part_names, part->uv.char_name);
       }
       else {
         const char* part_name = part->uv.op_name->uv.name;
         
         SPerl_PACKAGE* found_package = SPerl_HASH_search(package_symtable, part_name, strlen(part_name));
         if (found_package) {
-          SPerl_ARRAY_push(resolved_type_part_names, (void*) part_name);
+          SPerl_ARRAY_push(resolved_type_part_names, part_name);
         }
         else {
           SPerl_yyerror_format(sperl, "unknown package \"%s\" at %s line %d\n", part_name, op_type->file, op_type->line);

--- a/t/sperl_t_array.c
+++ b/t/sperl_t_array.c
@@ -58,7 +58,7 @@ int main(int argc, char *argv[])
     
     // push pointer value
     const char* value3 = "foo";
-    SPerl_ARRAY_push(array, (void*) value3);
+    SPerl_ARRAY_push(array, value3);
     OK(array->values[2] == value3);
   }
 


### PR DESCRIPTION
fix #23 
SPerl_ARRAY_pushconst の引数をvoid *からconst void * に修正ましました。
また、上記の関数の中でconst外しをしています。そこに「わかってて敢えてやっている」の意味のコメントを入れておきました。